### PR TITLE
fix mname mapping, two lnames were being created

### DIFF
--- a/lib/submit/submitSchema.rb
+++ b/lib/submit/submitSchema.rb
@@ -38,7 +38,7 @@ def transformPeople(uci, authOrEd, people)
       xml.send(authOrEd) {
         if np = person[:nameParts]
           np[:fname] and xml.fname(np[:fname])
-          np[:mname] and xml.lname(np[:mname])
+          np[:mname] and xml.mname(np[:mname])
           np[:lname] and xml.lname(np[:lname])
           np[:suffix] and xml.suffix(np[:suffix])
           np[:institution] and xml.institution(np[:institution])


### PR DESCRIPTION
middle and last name were mapped in the API to the same field in the UCI schema (lname). This caused an error on deposit for any item that has an author with a middle name.