### PR TITLE
use sourceFeedURL in the deposit comment instead of hardcoded url

### DIFF
--- a/lib/submit/submitSchema.rb
+++ b/lib/submit/submitSchema.rb
@@ -267,7 +267,9 @@ def depositItem(input, replace:)
   uci = uciFromInput(input, fullArk)
 
   # Create the UCI metadata file on the submit server
+  source_url = input[:sourceFeedLink] || "oapolicy.universityofcalifornia.edu"
   actionVerb = replace == :files ? "Redeposited" : replace == :metadata ? "Updated" : "Deposited"
+  comment = input[:deposit_comment] || "'#{actionVerb} at #{source_url}' "
   Net::SSH.start($submitServer, $submitUser, **$submitSSHOpts) do |ssh|
     # Verify that the ARK isn't a dupe for this publication ID (can happen if old incomplete
     # items aren't properly cleaned up).
@@ -286,7 +288,7 @@ def depositItem(input, replace:)
     out = ssh.exec_sc!("/apps/eschol/subi/lib/subiGuts.rb " +
                  "#{replace == :files ? "--replaceFiles" : replace == :metadata ? "--replaceMetadata" : "--depositItem"} " +
                  "#{shortArk} " +
-                 "'#{actionVerb} at oapolicy.universityofcalifornia.edu' " +
+                 "#{comment} " +
                  "#{input['submitterEmail'] || "''" } -", metaText)
     puts "stdout from main subiGuts operation:\n#{out[:stdout]}"
 

--- a/lib/submit/submitSchema.rb
+++ b/lib/submit/submitSchema.rb
@@ -269,7 +269,7 @@ def depositItem(input, replace:)
   # Create the UCI metadata file on the submit server
   source_url = input[:sourceFeedLink] || "oapolicy.universityofcalifornia.edu"
   actionVerb = replace == :files ? "Redeposited" : replace == :metadata ? "Updated" : "Deposited"
-  comment = input[:deposit_comment] || "'#{actionVerb} at #{source_url}' "
+  comment = "'#{actionVerb} at #{source_url}' "
   Net::SSH.start($submitServer, $submitUser, **$submitSSHOpts) do |ssh|
     # Verify that the ARK isn't a dupe for this publication ID (can happen if old incomplete
     # items aren't properly cleaned up).


### PR DESCRIPTION
I used an existing field "sourceFeedLink" to generate a deposit comment that more accurately describes where each item is coming from.  However, I'm not totally sure how this field is used elsewhere.  Let me know if you think it would be better to make a new field.