### PR TITLE
set eb timezone to pacific time to try and fix OAI problem

### DIFF
--- a/.ebextensions/change_timezone.config
+++ b/.ebextensions/change_timezone.config
@@ -1,3 +1,3 @@
 commands:
-  00_change_timezone:
-    command: ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
+  01_set_timezone:
+    command: "sudo timedatectl set-timezone America/Los_Angeles"

--- a/.ebextensions/change_timezone.config
+++ b/.ebextensions/change_timezone.config
@@ -1,0 +1,3 @@
+commands:
+  00_change_timezone:
+    command: ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime


### PR DESCRIPTION
Since EB local time is always UTC and I can only set sinatra timezone to local or UTC we need to change local time to pacific time to try and match  to DB timezone.

I used this example as a guide: https://wiki.lyrasis.org/display/~elr37/Setting+System+Time+to+ET+on+AWS+Elastic+Beanstalk