### PR TITLE
PUBD-927 Add authors to RSS feed

### DIFF
--- a/lib/access/rss.rb
+++ b/lib/access/rss.rb
@@ -21,7 +21,6 @@ def serveUnitRSS(unitID)
           authors {
             nodes {
               name
-            	orcid
             }
           }
         }
@@ -37,7 +36,7 @@ def serveUnitRSS(unitID)
     descrip = item['abstract'] && !item['abstract'].strip.empty? ? item['abstract'] : item['title']
     descrip.size > 1000 and descrip = descrip[0..((descrip.index(' ',990) || 1000)-1)] + "..."
     date = DateTime.parse(item['added']).rfc2822
-    authors = item['authors']
+    authors = item['authors']['nodes']
     itemChunks << xmlGen('''
       <item>
         <title><%= item["title"] %></title>
@@ -47,7 +46,7 @@ def serveUnitRSS(unitID)
         <pubDate><%= date %></pubDate>
         <% authors.each do |author| %>
           <author>
-            <name><%= author.name =%></name>
+            <name><%= author["name"] =%></name>
           </author>
         <% end %>
       </item>''', binding, xml_header: false)

--- a/lib/access/rss.rb
+++ b/lib/access/rss.rb
@@ -18,6 +18,12 @@ def serveUnitRSS(unitID)
           abstract
           permalink
           added
+          authors {
+            nodes {
+              name
+            	orcid
+            }
+          }
         }
       }
     }
@@ -31,6 +37,7 @@ def serveUnitRSS(unitID)
     descrip = item['abstract'] && !item['abstract'].strip.empty? ? item['abstract'] : item['title']
     descrip.size > 1000 and descrip = descrip[0..((descrip.index(' ',990) || 1000)-1)] + "..."
     date = DateTime.parse(item['added']).rfc2822
+    authors = item['authors']
     itemChunks << xmlGen('''
       <item>
         <title><%= item["title"] %></title>

--- a/lib/access/rss.rb
+++ b/lib/access/rss.rb
@@ -45,6 +45,11 @@ def serveUnitRSS(unitID)
         <description><%= descrip %></description>
         <guid isPermaLink="true"><%= item["permalink"] %></guid>
         <pubDate><%= date %></pubDate>
+        <% authors.each do |author| %>
+          <author>
+            <name><%= author.name =%></name>
+          </author>
+        <% end %>
       </item>''', binding, xml_header: false)
   }
 


### PR DESCRIPTION
This pull request addresses PUBD-927, which requests that author names be added to the RSS feed for eScholarship. The eScholarship RSS feed uses escholApi directly.