### PR TITLE
Uncapped author and contributor first: parameter.

### DIFF
--- a/lib/access/accessSchema.rb
+++ b/lib/access/accessSchema.rb
@@ -639,7 +639,7 @@ class ItemType < GraphQL::Schema::Object
 
   field :authors, AuthorsType, "All authors (can be long)" do
     argument :first, Int, default_value: 100, prepare: ->(val, ctx) {
-      (val.nil? || (val >= 1 && val <= 500)) or return GraphQL::ExecutionError.new("'first' must be in range 1..500")
+      (val.nil? || (val >= 1 && val <= 100000)) or return GraphQL::ExecutionError.new("'first' must be in range 1..100000")
       return val
     }
     argument :more, String, required: false
@@ -747,7 +747,7 @@ class ItemType < GraphQL::Schema::Object
 
   field :contributors, ContributorsType, "Editors, advisors, etc. (if any)" do
     argument :first, Int, default_value: 100, prepare: ->(val, ctx) {
-      (val.nil? || (val >= 1 && val <= 500)) or return GraphQL::ExecutionError.new("'first' must be in range 1..500")
+      (val.nil? || (val >= 1 && val <= 100000)) or return GraphQL::ExecutionError.new("'first' must be in range 1..100000")
       return val
     }
     argument :more, String, required: false

--- a/lib/access/accessSchema.rb
+++ b/lib/access/accessSchema.rb
@@ -639,7 +639,7 @@ class ItemType < GraphQL::Schema::Object
 
   field :authors, AuthorsType, "All authors (can be long)" do
     argument :first, Int, default_value: 100, prepare: ->(val, ctx) {
-      (val.nil? || (val >= 1 && val <= 100000)) or return GraphQL::ExecutionError.new("'first' must be in range 1..100000")
+      (val.nil? || (val >= 1 && val <= 10000)) or return GraphQL::ExecutionError.new("'first' must be in range 1..10000")
       return val
     }
     argument :more, String, required: false
@@ -747,7 +747,7 @@ class ItemType < GraphQL::Schema::Object
 
   field :contributors, ContributorsType, "Editors, advisors, etc. (if any)" do
     argument :first, Int, default_value: 100, prepare: ->(val, ctx) {
-      (val.nil? || (val >= 1 && val <= 100000)) or return GraphQL::ExecutionError.new("'first' must be in range 1..100000")
+      (val.nil? || (val >= 1 && val <= 10000)) or return GraphQL::ExecutionError.new("'first' must be in range 1..10000")
       return val
     }
     argument :more, String, required: false


### PR DESCRIPTION
- This change un-caps the number of authors the eSchol API can return, by raising the maximum value of the "first" parameter on the access query from 500 to 10000.
- This is being done to prevent unnecessary re-processing of hyperauthored papers. This has knock-on effects for the Merrit team.
- This change has been running on staging for about two weeks, and our monitoring hasn't revealed anything concerning.