### PR TITLE
add "CONFERENCE_PROCEEDINGS" to UnitTypeEnum

### DIFF
--- a/lib/access/accessSchema.rb
+++ b/lib/access/accessSchema.rb
@@ -363,6 +363,7 @@ class UnitTypeEnum < GraphQL::Schema::Enum
   value("ROOT",             "eScholarship itself")
   value("SEMINAR_SERIES",   "series of seminars")
   value("SERIES",           "general series of publications")
+  value("CONFERENCE_PROCEEDINGS", "proceedings of a conference")
 end
 ###################################################################################################
 class UnitType < GraphQL::Schema::Object


### PR DESCRIPTION
Fix for [eSchol API error for new conference_proceedings unit type](https://github.com/eScholarship/jschol/issues/878).