### PR TITLE
Use FORCE INDEX on order by UPDATE

### DIFF
--- a/lib/access/accessSchema.rb
+++ b/lib/access/accessSchema.rb
@@ -1018,6 +1018,16 @@ class ItemsData
     query = query.order(ascending ? field : Sequel::desc(field),
                         ascending ? :id   : Sequel::desc(:id))
 
+    # If the query sorts by updated, override the FROM clause to include updated indexes
+    # This is required to prevent OOM errors on the MySQL sort buffer
+    if (args[:order] =~ /UPDATED/)
+      if ascending
+        query = query.from(Sequel.lit("`items` FORCE INDEX(items_updated_id_asc_index)"))
+      else
+        query = query.from(Sequel.lit("`items` FORCE INDEX(items_updated_id_desc_index)"))
+      end
+    end
+
     # Apply limits as specified
     if args[:before]
       # Exclusive ('<'), so that queries like "after: 2018-11-01 before: 2018-12-01" work as user expects.


### PR DESCRIPTION
This is a minimally-invasive way to coerce the eSchol API to generate MySQL for the eSchol DB that includes the `FORCE INDEX()` statement.

Tested and working on local machine connecting to the eSchol DEV DB.

Example MySQL output from eSchol API:

```
I, [2026-02-25T10:07:32.712046 #63907]  INFO -- : 

(0.113969s) 
SELECT * 
FROM `items` 
FORCE INDEX(items_updated_id_desc_index) 
WHERE ((`status` IN ('published', 'embargoed')) AND (updated < '2026-02-25') AND (updated >= '2024-01-01')) 
ORDER BY `updated` DESC, `id` DESC LIMIT 100
```