### PR TITLE
Added second PRIMARY to force index statement

### DIFF
--- a/lib/access/accessSchema.rb
+++ b/lib/access/accessSchema.rb
@@ -1022,9 +1022,9 @@ class ItemsData
     # This is required to prevent OOM errors on the MySQL sort buffer
     if (args[:order] =~ /UPDATED/)
       if ascending
-        query = query.from(Sequel.lit("`items` FORCE INDEX(items_updated_id_asc_index)"))
+        query = query.from(Sequel.lit("`items` FORCE INDEX(items_updated_id_asc_index, PRIMARY)"))
       else
-        query = query.from(Sequel.lit("`items` FORCE INDEX(items_updated_id_desc_index)"))
+        query = query.from(Sequel.lit("`items` FORCE INDEX(items_updated_id_desc_index, PRIMARY)"))
       end
     end
 


### PR DESCRIPTION
Adds a secondary index to the `FORCE INDEX` statement (`item.id` e.g., `PRIMARY`), which facilitates quicker processing of uncorrelated subqueries in `WHERE` statements, e.g.:

```
SELECT * FROM `items`
FORCE INDEX(items_updated_id_desc_index, PRIMARY)
where
	((`status` IN ('published', 'embargoed'))
	AND (id in (select item_id
				from unit_items
				where unit_id = 'csw_thinkinggender'))
	AND (updated < '2026-03-11T11:55:55-07:00')
	AND (updated >= '2011-03-18T14:32:42-07:00'))
ORDER by
	`updated` DESC,
	`id` desc
LIMIT 500;
```