### PR TITLE
Continuing index working

### DIFF
--- a/lib/access/accessSchema.rb
+++ b/lib/access/accessSchema.rb
@@ -1026,7 +1026,7 @@ class ItemsData
     when "UPDATED_DESC"
       query = query.from(Sequel.lit("`items` FORCE INDEX(items_updated_id_desc_index)"))
     when "ADDED_ASC", "ADDED_DESC"
-      query = query.from(Sequel.lit("`items` FORCE INDEX(items_status_added_id_index)"))
+      query = query.from(Sequel.lit("`items` FORCE INDEX(items_status_added_id_index, items_eschol_date_index)"))
     end
 
     # Apply limits as specified


### PR DESCRIPTION
For GraphQL queries to the items table that sort by `ADDED_ASC` or `ADDED_DESC`, this includes a 2nd (pre-existing) index in the MySQL `FORCE INDEX()` statement generated by the eScholAPI.

This circumvents the optimizer's `filesort` selection for an Elements query used during its monthly refresh from eScholarship (which was throwing very-occasional `OOM`s prior to April, and consistently afterword.)

Deployed on prd for testing 2026-04-08, no ill effects observed in the pipeline.